### PR TITLE
[Recognize Text] Add RecognitionLevel

### DIFF
--- a/packages/apple_vision_recognize_text/darwin/Classes/AppleVisionRecognizeTextPlugin.swift
+++ b/packages/apple_vision_recognize_text/darwin/Classes/AppleVisionRecognizeTextPlugin.swift
@@ -41,15 +41,16 @@ public class AppleVisionRecognizeTextPlugin: NSObject, FlutterPlugin {
             let height = arguments["height"] as? Double ?? 0
             let candidates = arguments["candidates"] as? Int ?? 1
             let orientation = arguments["orientation"] as? String ?? "downMirrored"
+            let recognitionLevel = arguments["recognitionLevel"] as? String ?? "accurate"
 
             #if os(iOS)
                 if #available(iOS 13.0, *) {
-                    return result(convertImage(Data(data.data),CGSize(width: width , height: height),candidates,CIFormat.BGRA8,orientation))
+                    return result(convertImage(Data(data.data),CGSize(width: width , height: height),candidates,CIFormat.BGRA8,orientation,recognitionLevel))
                 } else {
                     return result(FlutterError(code: "INVALID OS", message: "requires version 12.0", details: nil))
                 }
             #elseif os(macOS)
-                return result(convertImage(Data(data.data),CGSize(width: width , height: height),candidates,CIFormat.ARGB8,orientation))
+                return result(convertImage(Data(data.data),CGSize(width: width , height: height),candidates,CIFormat.ARGB8,orientation,recognitionLevel))
             #endif
         default:
             result(FlutterMethodNotImplemented)
@@ -60,7 +61,7 @@ public class AppleVisionRecognizeTextPlugin: NSObject, FlutterPlugin {
     #if os(iOS)
     @available(iOS 13.0, *)
     #endif
-    func convertImage(_ data: Data,_ imageSize: CGSize, _ candidates: Int,_ format: CIFormat,_ oriString: String) -> [String:Any?]{
+    func convertImage(_ data: Data,_ imageSize: CGSize, _ candidates: Int,_ format: CIFormat,_ oriString: String,_ recognitionLevelString: String) -> [String:Any?]{
         let imageRequestHandler:VNImageRequestHandler
 
         var orientation:CGImagePropertyOrientation = CGImagePropertyOrientation.downMirrored
@@ -91,6 +92,19 @@ public class AppleVisionRecognizeTextPlugin: NSObject, FlutterPlugin {
                 break
         }
 
+        var recognitionLevel:VNRequestTextRecognitionLevel = VNRequestTextRecognitionLevel.accurate
+        switch recognitionLevelString{
+            case "fast":
+                recognitionLevel = VNRequestTextRecognitionLevel.fast
+                break
+            case "accurate":
+                recognitionLevel = VNRequestTextRecognitionLevel.accurate
+                break
+            default:
+                recognitionLevel = VNRequestTextRecognitionLevel.accurate
+                break
+        }
+
         if data.count == (Int(imageSize.height)*Int(imageSize.width)*4){
             // Create a bitmap graphics context with the sample buffer data
             let context =  CIImage(bitmapData: data, bytesPerRow: Int(imageSize.width)*4, size: imageSize, format: format, colorSpace: nil)
@@ -104,8 +118,7 @@ public class AppleVisionRecognizeTextPlugin: NSObject, FlutterPlugin {
         var event:[String:Any?] = ["name":"noData"];
 
         do {
-            try
-            imageRequestHandler.perform([VNRecognizeTextRequest { (request, error)in
+            let request = VNRecognizeTextRequest { (request, error)in
                 if error == nil {
                     
                     if let results = request.results as? [VNRecognizedTextObservation] {
@@ -126,7 +139,9 @@ public class AppleVisionRecognizeTextPlugin: NSObject, FlutterPlugin {
                     event = ["name":"error","code": "No Text Detected", "message": error!.localizedDescription]
                     print(error!.localizedDescription)
                 }
-            }])
+            }
+            request.recognitionLevel = recognitionLevel
+            try imageRequestHandler.perform([request])
         } catch {
             event = ["name":"error","code": "Data Corropted", "message": error.localizedDescription]
             print(error)

--- a/packages/apple_vision_recognize_text/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/apple_vision_recognize_text/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/apple_vision_recognize_text/example/lib/main.dart
+++ b/packages/apple_vision_recognize_text/example/lib/main.dart
@@ -61,7 +61,11 @@ class _VisionRT extends State<VisionRT>{
         }
         if(mounted) {
           Uint8List? image = i.bytes;
-          visionController.processImage(image!, imageSize).then((data){
+          visionController.processImage(
+            image: image!,
+            imageSize: imageSize,
+            recognitionLevel: RecognitionLevel.accurate,
+          ).then((data){
             textData = data;
             setState(() {
               

--- a/packages/apple_vision_recognize_text/lib/apple_vision_recognize_text.dart
+++ b/packages/apple_vision_recognize_text/lib/apple_vision_recognize_text.dart
@@ -1,4 +1,4 @@
 library apple_vision_recognize_text;
 
 export 'src/recognize_text_controller.dart';
-
+export 'src/recognition_level.dart';

--- a/packages/apple_vision_recognize_text/lib/src/recognition_level.dart
+++ b/packages/apple_vision_recognize_text/lib/src/recognition_level.dart
@@ -1,4 +1,4 @@
-/// Constants that identify the performance and accuracy of the text recognition.
+/// A value that determines whether the request prioritizes accuracy or speed in text recognition.
 enum RecognitionLevel {
   /// Fast text recognition returns results more quickly at the expense of accuracy.
   fast,

--- a/packages/apple_vision_recognize_text/lib/src/recognition_level.dart
+++ b/packages/apple_vision_recognize_text/lib/src/recognition_level.dart
@@ -1,0 +1,9 @@
+/// Constants that identify the performance and accuracy of the text recognition.
+enum RecognitionLevel {
+  /// Fast text recognition returns results more quickly at the expense of accuracy.
+  fast,
+
+  /// Accurate text recognition takes more time to produce a more comprehensive result.
+  accurate,
+  ;
+}

--- a/packages/apple_vision_recognize_text/lib/src/recognize_text_controller.dart
+++ b/packages/apple_vision_recognize_text/lib/src/recognize_text_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:apple_vision_recognize_text/apple_vision_recognize_text.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:apple_vision_commons/apple_vision_commons.dart';
@@ -25,7 +26,12 @@ class AppleVisionRecognizeTextController {
   /// [imageSize] as Size is the size of the image that is being processed
   /// 
   /// [orientation] The orientation of the image
-  Future<List<RecognizedText>?> processImage(Uint8List image, Size imageSize,[ImageOrientation orientation = ImageOrientation.down]) async{
+  Future<List<RecognizedText>?> processImage({
+    required Uint8List image,
+    required Size imageSize,
+    ImageOrientation orientation = ImageOrientation.down,
+    RecognitionLevel recognitionLevel = RecognitionLevel.accurate,
+  }) async{
     try {
       final data = await _methodChannel.invokeMapMethod<String, dynamic>(  
         'process',
@@ -33,7 +39,8 @@ class AppleVisionRecognizeTextController {
           'width': imageSize.width,
           'height':imageSize.height,
           'candidates': numberOfCandidates,
-          'orientation': orientation.name
+          'orientation': orientation.name,
+          'recognitionLevel': recognitionLevel.name,
           //'languages': languages
         },
       );

--- a/packages/apple_vision_recognize_text/lib/src/recognize_text_controller.dart
+++ b/packages/apple_vision_recognize_text/lib/src/recognize_text_controller.dart
@@ -26,6 +26,8 @@ class AppleVisionRecognizeTextController {
   /// [imageSize] as Size is the size of the image that is being processed
   /// 
   /// [orientation] The orientation of the image
+  /// 
+  /// [recognitionLevel] A value that determines whether the request prioritizes accuracy or speed in text recognition.
   Future<List<RecognizedText>?> processImage({
     required Uint8List image,
     required Size imageSize,


### PR DESCRIPTION
Recognition Level can be specified.
In conjunction with this change, `processImage` was changed to named parameters.

( I know FAST might not use it because of the terrible detection results... )